### PR TITLE
refactor: rename `state_id` to `session_id` across codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ from nova_act import NovaAct
 
 with with_browserstate(
     user_id="demo-user",
-    state_id="nova-session",
+    session_id="nova-session",
     provider="redis",  # or 'local', 's3', 'gcs'
     redis_options={"host": "localhost", "port": 6379}
 ) as user_data_dir:
@@ -41,7 +41,7 @@ from nova_act import NovaAct
 
 user_data_dir = mount_browserstate(
     user_id="demo",
-    state_id="session1",
+    session_id="session1",
     provider="local"
 )
 
@@ -69,7 +69,7 @@ finally:
 ---
 
 ## 🤝 Contributing
-PRs welcome — especially if you’re using BrowserState with other automation tools.
+PRs welcome — especially if you're using BrowserState with other automation tools.
 
 ---
 

--- a/browserstate_nova_adapter/__init__.py
+++ b/browserstate_nova_adapter/__init__.py
@@ -7,7 +7,7 @@ _user_browserstate_instance = None  # Global so unmount can access it
 @contextmanager
 def with_browserstate(
     user_id: str,
-    state_id: str,
+    session_id: str,
     provider: Literal["local", "s3", "gcs", "redis"] = "local",
     storage_path: Optional[str] = None,
     temp_dir: Optional[str] = None,
@@ -18,18 +18,18 @@ def with_browserstate(
     
     Args:
         user_id: Unique identifier for the user
-        state_id: Identifier for this specific browser state
+        session_id: Identifier for this specific browser session
         provider: Storage provider ("local", "s3", "gcs", "redis")
         storage_path: Path for local storage (used with "local" provider)
-        temp_dir: Path for temporary directory to mount state
+        temp_dir: Path for temporary directory to mount session
         redis_options: Configuration for Redis connection (used with "redis" provider)
         
     Yields:
-        str: Path to the mounted browser state directory to use with Nova
+        str: Path to the mounted browser session directory to use with Nova
     """
     state_path = mount_browserstate(
         user_id=user_id,
-        state_id=state_id,
+        session_id=session_id,
         provider=provider,
         storage_path=storage_path,
         temp_dir=temp_dir,
@@ -43,25 +43,25 @@ def with_browserstate(
 
 def mount_browserstate(
     user_id: str,
-    state_id: str,
+    session_id: str,
     provider: Literal["local", "s3", "gcs", "redis"] = "local",
     storage_path: Optional[str] = None,
     temp_dir: Optional[str] = None,
     redis_options: Optional[dict] = None
 ) -> str:
     """
-    Mount browser state for use with Nova Act.
+    Mount browser session for use with Nova Act.
     
     Args:
         user_id: Unique identifier for the user
-        state_id: Identifier for this specific browser state
+        session_id: Identifier for this specific browser session
         provider: Storage provider ("local", "s3", "gcs", "redis")
         storage_path: Path for local storage (used with "local" provider)
-        temp_dir: Path for temporary directory to mount state
+        temp_dir: Path for temporary directory to mount session
         redis_options: Configuration for Redis connection (used with "redis" provider)
         
     Returns:
-        str: Path to the mounted browser state directory to use with Nova
+        str: Path to the mounted browser session directory to use with Nova
     """
     global _user_browserstate_instance
     options = BrowserStateOptions(
@@ -72,16 +72,16 @@ def mount_browserstate(
         redis_options=redis_options
     )
     _user_browserstate_instance = BrowserState(options)
-    return _user_browserstate_instance.mount(state_id=state_id)
+    return _user_browserstate_instance.mount_session(session_id=session_id)["path"]
 
 
 def unmount_browserstate():
     """
-    Unmount the currently mounted browser state.
+    Unmount the currently mounted browser session.
     
-    This function should be called when finished with the browser state to ensure proper cleanup.
+    This function should be called when finished with the browser session to ensure proper cleanup.
     """
     global _user_browserstate_instance
     if _user_browserstate_instance:
-        _user_browserstate_instance.unmount()
+        _user_browserstate_instance.unmount_session()
         _user_browserstate_instance = None 

--- a/examples/advanced_usage.py
+++ b/examples/advanced_usage.py
@@ -16,7 +16,7 @@ def run_with_context_manager():
     try:
         with with_browserstate(
             user_id="demo-user",
-            state_id="robust-session",
+            session_id="robust-session",
             provider="redis",
             redis_options={
                 "host": "localhost",
@@ -26,7 +26,7 @@ def run_with_context_manager():
                 "ttl": 86400  # 24 hours
             }
         ) as user_data_dir:
-            logger.info(f"Browser state mounted at: {user_data_dir}")
+            logger.info(f"Browser session mounted at: {user_data_dir}")
             
             try:
                 with NovaAct(starting_page="https://example.com", user_data_dir=user_data_dir) as nova:
@@ -45,19 +45,19 @@ def run_with_context_manager():
                 logger.error(f"Error during Nova automation: {e}")
                 # The with_browserstate context manager will still handle cleanup
     except Exception as e:
-        logger.critical(f"Error with browser state: {e}")
+        logger.critical(f"Error with browser session: {e}")
 
 # Example 2: Manual mounting with separate sessions
 def run_with_manual_mounting():
-    # First mount the state to ensure we have it
+    # First mount the session to ensure we have it
     try:
         user_data_dir = mount_browserstate(
             user_id="manual-user",
-            state_id="multi-session",
+            session_id="multi-session",
             provider="local",
             storage_path="./browser_storage"
         )
-        logger.info(f"Browser state mounted at: {user_data_dir}")
+        logger.info(f"Browser session mounted at: {user_data_dir}")
         
         # First session
         try:
@@ -69,11 +69,11 @@ def run_with_manual_mounting():
         except Exception as e:
             logger.error(f"Error in first session: {e}")
         
-        # Second session (reusing the same mounted state)
+        # Second session (reusing the same mounted session)
         try:
             with NovaAct(starting_page="https://dashboard.example.com", user_data_dir=user_data_dir) as nova:
                 logger.info("Starting second session")
-                # We're already logged in because the state persists
+                # We're already logged in because the session persists
                 nova.act("check notifications")
                 nova.act("log out")
                 logger.info("Second session completed")
@@ -81,14 +81,14 @@ def run_with_manual_mounting():
             logger.error(f"Error in second session: {e}")
         
     except Exception as e:
-        logger.critical(f"Error mounting browser state: {e}")
+        logger.critical(f"Error mounting browser session: {e}")
     finally:
         # Always clean up
         try:
             unmount_browserstate()
-            logger.info("Browser state unmounted successfully")
+            logger.info("Browser session unmounted successfully")
         except Exception as e:
-            logger.error(f"Error unmounting browser state: {e}")
+            logger.error(f"Error unmounting browser session: {e}")
 
 if __name__ == "__main__":
     logger.info("Starting example with context manager")

--- a/examples/provider_configurations.py
+++ b/examples/provider_configurations.py
@@ -4,7 +4,7 @@ from nova_act import NovaAct
 # Example with local storage provider
 with with_browserstate(
     user_id="local-user",
-    state_id="local-session",
+    session_id="local-session",
     provider="local",
     storage_path="/path/to/storage"
 ) as user_data_dir:
@@ -14,7 +14,7 @@ with with_browserstate(
 # Example with Redis provider
 with with_browserstate(
     user_id="redis-user",
-    state_id="redis-session",
+    session_id="redis-session",
     provider="redis",
     redis_options={
         "host": "localhost",
@@ -31,7 +31,7 @@ with with_browserstate(
 # Example with S3 provider (requires boto3)
 with with_browserstate(
     user_id="s3-user",
-    state_id="s3-session",
+    session_id="s3-session",
     provider="s3",
     # S3 configuration is handled through boto3 credentials
     # Make sure AWS credentials are configured in your environment
@@ -42,7 +42,7 @@ with with_browserstate(
 # Example with Google Cloud Storage provider (requires google-cloud-storage)
 with with_browserstate(
     user_id="gcs-user",
-    state_id="gcs-session",
+    session_id="gcs-session",
     provider="gcs",
     # GCS configuration is handled through application default credentials
     # Make sure GCP credentials are configured in your environment

--- a/examples/simple_usage.py
+++ b/examples/simple_usage.py
@@ -4,7 +4,7 @@ from nova_act import NovaAct
 # Example 1: Using with context manager
 with with_browserstate(
     user_id="demo-user",
-    state_id="nova-session",
+    session_id="nova-session",
     provider="redis",  # or 'local', 's3', 'gcs'
     redis_options={"host": "localhost", "port": 6379}
 ) as user_data_dir:
@@ -16,7 +16,7 @@ from browserstate_nova_adapter import mount_browserstate, unmount_browserstate
 
 user_data_dir = mount_browserstate(
     user_id="demo",
-    state_id="session1",
+    session_id="session1",
     provider="local"
 )
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -11,24 +11,25 @@ class TestBrowserStateNovaAdapter(unittest.TestCase):
         
         # Setup mock
         mock_instance = MagicMock()
-        mock_instance.mount.return_value = "/tmp/browser_data"
+        mock_session = {"path": "/tmp/browser_data"}
+        mock_instance.mount_session.return_value = mock_session
         mock_browserstate.return_value = mock_instance
         
         # Test mounting
         result = mount_browserstate(
             user_id="test-user",
-            state_id="test-session",
+            session_id="test-session",
             provider="local"
         )
         
         # Assertions
         self.assertEqual(result, "/tmp/browser_data")
         mock_browserstate.assert_called_once()
-        mock_instance.mount.assert_called_once_with(state_id="test-session")
+        mock_instance.mount_session.assert_called_once_with(session_id="test-session")
         
         # Test unmounting
         unmount_browserstate()
-        mock_instance.unmount.assert_called_once()
+        mock_instance.unmount_session.assert_called_once()
     
     @patch('browserstate_nova_adapter.BrowserState')
     def test_with_browserstate_context_manager(self, mock_browserstate):
@@ -36,21 +37,22 @@ class TestBrowserStateNovaAdapter(unittest.TestCase):
         
         # Setup mock
         mock_instance = MagicMock()
-        mock_instance.mount.return_value = "/tmp/browser_data"
+        mock_session = {"path": "/tmp/browser_data"}
+        mock_instance.mount_session.return_value = mock_session
         mock_browserstate.return_value = mock_instance
         
         # Test context manager
         with with_browserstate(
             user_id="test-user",
-            state_id="test-session",
+            session_id="test-session",
             provider="local"
         ) as user_data_dir:
             self.assertEqual(user_data_dir, "/tmp/browser_data")
             mock_browserstate.assert_called_once()
-            mock_instance.mount.assert_called_once()
+            mock_instance.mount_session.assert_called_once()
         
         # Verify unmount was called
-        mock_instance.unmount.assert_called_once()
+        mock_instance.unmount_session.assert_called_once()
     
     @patch('browserstate_nova_adapter.BrowserState')
     def test_with_browserstate_exception_handling(self, mock_browserstate):
@@ -58,14 +60,15 @@ class TestBrowserStateNovaAdapter(unittest.TestCase):
         
         # Setup mock
         mock_instance = MagicMock()
-        mock_instance.mount.return_value = "/tmp/browser_data"
+        mock_session = {"path": "/tmp/browser_data"}
+        mock_instance.mount_session.return_value = mock_session
         mock_browserstate.return_value = mock_instance
         
         # Test context manager with exception
         try:
             with with_browserstate(
                 user_id="test-user",
-                state_id="test-session",
+                session_id="test-session",
                 provider="local"
             ) as user_data_dir:
                 self.assertEqual(user_data_dir, "/tmp/browser_data")
@@ -74,7 +77,7 @@ class TestBrowserStateNovaAdapter(unittest.TestCase):
             pass
         
         # Verify unmount was still called despite exception
-        mock_instance.unmount.assert_called_once()
+        mock_instance.unmount_session.assert_called_once()
 
 if __name__ == '__main__':
     unittest.main() 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -9,13 +9,14 @@ class TestProvidersConfig(unittest.TestCase):
         
         # Setup mock
         mock_instance = MagicMock()
-        mock_instance.mount.return_value = "/tmp/browser_data"
+        mock_session = {"path": "/tmp/browser_data"}
+        mock_instance.mount_session.return_value = mock_session
         mock_browserstate.return_value = mock_instance
         
         # Test with local provider
         result = mount_browserstate(
             user_id="test-user",
-            state_id="test-session",
+            session_id="test-session",
             provider="local",
             storage_path="/custom/storage/path"
         )
@@ -33,7 +34,8 @@ class TestProvidersConfig(unittest.TestCase):
         
         # Setup mock
         mock_instance = MagicMock()
-        mock_instance.mount.return_value = "/tmp/browser_data"
+        mock_session = {"path": "/tmp/browser_data"}
+        mock_instance.mount_session.return_value = mock_session
         mock_browserstate.return_value = mock_instance
         
         # Test with Redis provider
@@ -48,7 +50,7 @@ class TestProvidersConfig(unittest.TestCase):
         
         result = mount_browserstate(
             user_id="test-user",
-            state_id="test-session",
+            session_id="test-session",
             provider="redis",
             redis_options=redis_options
         )
@@ -66,13 +68,14 @@ class TestProvidersConfig(unittest.TestCase):
         
         # Setup mock
         mock_instance = MagicMock()
-        mock_instance.mount.return_value = "/tmp/browser_data"
+        mock_session = {"path": "/tmp/browser_data"}
+        mock_instance.mount_session.return_value = mock_session
         mock_browserstate.return_value = mock_instance
         
         # Test with S3 provider
         result = mount_browserstate(
             user_id="test-user",
-            state_id="test-session",
+            session_id="test-session",
             provider="s3"
         )
         
@@ -88,13 +91,14 @@ class TestProvidersConfig(unittest.TestCase):
         
         # Setup mock
         mock_instance = MagicMock()
-        mock_instance.mount.return_value = "/tmp/browser_data"
+        mock_session = {"path": "/tmp/browser_data"}
+        mock_instance.mount_session.return_value = mock_session
         mock_browserstate.return_value = mock_instance
         
         # Test with GCS provider
         result = mount_browserstate(
             user_id="test-user",
-            state_id="test-session",
+            session_id="test-session",
             provider="gcs"
         )
         


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rename `state_id` to `session_id` across codebase, update examples, tests, and documentation for consistency.
> 
>   - **Renaming**:
>     - Rename `state_id` to `session_id` in `with_browserstate()`, `mount_browserstate()`, and `unmount_browserstate()` in `__init__.py`.
>     - Update all example scripts (`advanced_usage.py`, `provider_configurations.py`, `simple_usage.py`) to use `session_id`.
>     - Update tests in `test_adapter.py` and `test_providers.py` to reflect `session_id` changes.
>   - **Functionality**:
>     - Modify `mount_browserstate()` to use `mount_session()` and `unmount_browserstate()` to use `unmount_session()` in `__init__.py`.
>   - **Documentation**:
>     - Update `README.md` to reflect `session_id` terminology.
>     - Fix minor typo in `README.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=browserstate-org%2Fbrowserstate-nova-adapter&utm_source=github&utm_medium=referral)<sup> for 0ab71087ccdd4ff319fd634ffce21f5fc0cbc6e0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->