### PR TITLE
Add: Amazon shopping example with session persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ This example demonstrates how to maintain login state and shopping carts across 
 ```python
 from browserstate_nova_adapter import with_browserstate, create_session_config
 from nova_act import NovaAct
-import os
 
 # Create a reusable session configuration
 amazon_config = create_session_config(

--- a/README.md
+++ b/README.md
@@ -82,3 +82,73 @@ MIT
 Nova sessions reset browser context every run.
 This adapter makes Nova Act automations behave like real users — with memory.
 It wraps `BrowserState`'s mounting logic, handles cleanup, and supports Redis/S3/local/gcs.
+
+## 🌐 Practical Example: Amazon Shopping with Session Persistence
+
+This example demonstrates how to maintain login state and shopping carts across multiple runs when automating Amazon shopping tasks.
+
+```python
+from browserstate_nova_adapter import with_browserstate
+from nova_act import NovaAct
+import os
+
+# Step 1: Login to Amazon and add item to cart
+def amazon_login_and_add_to_cart():
+    with with_browserstate(
+        user_id="amazon-shopper",
+        session_id="amazon-shopping-session",
+        provider="local",
+        storage_path="./browser_sessions"
+    ) as user_data_dir:
+        with NovaAct(starting_page="https://www.amazon.com", user_data_dir=user_data_dir) as nova:
+            # Login to Amazon
+            nova.act("click on sign in")
+            nova.act("enter email address")
+            nova.act("click continue")
+            nova.act("enter password")
+            nova.act("click sign in")
+            
+            # Search for product
+            nova.act("search for wireless headphones")
+            nova.act("click on the first result")
+            
+            # Add to cart
+            nova.act("add to cart")
+            print("✅ Successfully logged in and added item to cart")
+            # Session will be automatically saved when exiting the context manager
+
+# Step 2: Later, complete the purchase using the same session (persisted cart and login)
+def amazon_complete_purchase():
+    with with_browserstate(
+        user_id="amazon-shopper",
+        session_id="amazon-shopping-session",  # Same session ID to reuse state
+        provider="local",
+        storage_path="./browser_sessions"
+    ) as user_data_dir:
+        with NovaAct(starting_page="https://www.amazon.com/cart", user_data_dir=user_data_dir) as nova:
+            # User is still logged in and cart is preserved from previous session
+            nova.act("verify the item is in cart")
+            nova.act("proceed to checkout")
+            nova.act("select shipping address")
+            nova.act("select payment method")
+            nova.act("place order")
+            print("🎉 Purchase completed successfully")
+
+# Run the shopping process in two separate steps
+if __name__ == "__main__":
+    print("Step 1: Login and add item to cart")
+    amazon_login_and_add_to_cart()
+    
+    input("Press Enter to continue with purchase...")
+    
+    print("Step 2: Complete the purchase")
+    amazon_complete_purchase()
+```
+
+This example demonstrates how BrowserState preserves:
+- Login sessions (cookies and authentication)
+- Shopping cart contents
+- User preferences and settings
+- Form data and autofill information
+
+All of this state persists between separate runs of your automation, making the Nova experience more like a real human user.

--- a/README.md
+++ b/README.md
@@ -88,18 +88,21 @@ It wraps `BrowserState`'s mounting logic, handles cleanup, and supports Redis/S3
 This example demonstrates how to maintain login state and shopping carts across multiple runs when automating Amazon shopping tasks.
 
 ```python
-from browserstate_nova_adapter import with_browserstate
+from browserstate_nova_adapter import with_browserstate, create_session_config
 from nova_act import NovaAct
 import os
 
+# Create a reusable session configuration
+amazon_config = create_session_config(
+    user_id="amazon-shopper",
+    session_id="amazon-shopping-session",
+    provider="local",
+    storage_path="./browser_sessions"
+)
+
 # Step 1: Login to Amazon and add item to cart
 def amazon_login_and_add_to_cart():
-    with with_browserstate(
-        user_id="amazon-shopper",
-        session_id="amazon-shopping-session",
-        provider="local",
-        storage_path="./browser_sessions"
-    ) as user_data_dir:
+    with with_browserstate(**amazon_config) as user_data_dir:
         with NovaAct(starting_page="https://www.amazon.com", user_data_dir=user_data_dir) as nova:
             # Login to Amazon
             nova.act("click on sign in")
@@ -119,12 +122,7 @@ def amazon_login_and_add_to_cart():
 
 # Step 2: Later, complete the purchase using the same session (persisted cart and login)
 def amazon_complete_purchase():
-    with with_browserstate(
-        user_id="amazon-shopper",
-        session_id="amazon-shopping-session",  # Same session ID to reuse state
-        provider="local",
-        storage_path="./browser_sessions"
-    ) as user_data_dir:
+    with with_browserstate(**amazon_config) as user_data_dir:
         with NovaAct(starting_page="https://www.amazon.com/cart", user_data_dir=user_data_dir) as nova:
             # User is still logged in and cart is preserved from previous session
             nova.act("verify the item is in cart")

--- a/browserstate_nova_adapter/__init__.py
+++ b/browserstate_nova_adapter/__init__.py
@@ -1,8 +1,57 @@
 from contextlib import contextmanager
-from typing import Optional, Literal
+from typing import Optional, Literal, Dict, Any
 from browserstate import BrowserState, BrowserStateOptions
 
 _user_browserstate_instance = None  # Global so unmount can access it
+
+def create_session_config(
+    user_id: str,
+    session_id: str,
+    provider: Literal["local", "s3", "gcs", "redis"] = "local",
+    storage_path: Optional[str] = None,
+    temp_dir: Optional[str] = None,
+    redis_options: Optional[dict] = None
+) -> Dict[str, Any]:
+    """
+    Create a reusable session configuration for with_browserstate.
+    
+    This helper function creates a configuration dictionary that can be
+    passed to with_browserstate or mount_browserstate using ** unpacking.
+    
+    Args:
+        user_id: Unique identifier for the user
+        session_id: Identifier for this specific browser session
+        provider: Storage provider ("local", "s3", "gcs", "redis")
+        storage_path: Path for local storage (used with "local" provider)
+        temp_dir: Path for temporary directory to mount session
+        redis_options: Configuration for Redis connection (used with "redis" provider)
+        
+    Returns:
+        Dict[str, Any]: Configuration dictionary for browser session
+        
+    Example:
+        ```python
+        # Create config once
+        my_config = create_session_config(
+            user_id="user1", 
+            session_id="session1",
+            provider="redis",
+            redis_options={"host": "localhost"}
+        )
+        
+        # Use in multiple places
+        with with_browserstate(**my_config) as user_data_dir:
+            # Use user_data_dir with Nova
+        ```
+    """
+    return {
+        "user_id": user_id,
+        "session_id": session_id,
+        "provider": provider,
+        "storage_path": storage_path,
+        "temp_dir": temp_dir,
+        "redis_options": redis_options
+    }
 
 @contextmanager
 def with_browserstate(

--- a/examples/session_configs.py
+++ b/examples/session_configs.py
@@ -1,0 +1,52 @@
+"""
+Example of using multiple session configurations for different purposes.
+"""
+from browserstate_nova_adapter import with_browserstate, create_session_config
+from nova_act import NovaAct
+
+# Create different configurations for different websites or tasks
+amazon_config = create_session_config(
+    user_id="web-user",
+    session_id="amazon-session",
+    provider="local",
+    storage_path="./browser_sessions"
+)
+
+gmail_config = create_session_config(
+    user_id="web-user",
+    session_id="gmail-session",
+    provider="local",
+    storage_path="./browser_sessions"
+)
+
+banking_config = create_session_config(
+    user_id="web-user",
+    session_id="banking-session",
+    provider="local",
+    storage_path="./browser_sessions"
+)
+
+def browse_amazon():
+    with with_browserstate(**amazon_config) as user_data_dir:
+        with NovaAct(starting_page="https://www.amazon.com", user_data_dir=user_data_dir) as nova:
+            nova.act("browse to deals of the day")
+
+def check_gmail():
+    with with_browserstate(**gmail_config) as user_data_dir:
+        with NovaAct(starting_page="https://mail.google.com", user_data_dir=user_data_dir) as nova:
+            nova.act("check for new emails")
+
+def check_banking():
+    with with_browserstate(**banking_config) as user_data_dir:
+        with NovaAct(starting_page="https://mybank.example.com", user_data_dir=user_data_dir) as nova:
+            nova.act("check account balance")
+
+if __name__ == "__main__":
+    # Each service uses a different session - isolation of cookies and state
+    browse_amazon()
+    check_gmail()
+    check_banking()
+    
+    # You can also reuse any session later by using the same configuration
+    print("Checking Amazon again with same session (retaining cart, login, etc.)")
+    browse_amazon() 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -5,6 +5,61 @@ import tempfile
 
 class TestBrowserStateNovaAdapter(unittest.TestCase):
     
+    def test_create_session_config(self):
+        from browserstate_nova_adapter import create_session_config
+        
+        # Test with minimal parameters
+        config = create_session_config(
+            user_id="test-user",
+            session_id="test-session"
+        )
+        
+        self.assertEqual(config["user_id"], "test-user")
+        self.assertEqual(config["session_id"], "test-session")
+        self.assertEqual(config["provider"], "local")
+        self.assertIsNone(config["storage_path"])
+        self.assertIsNone(config["temp_dir"])
+        self.assertIsNone(config["redis_options"])
+        
+        # Test with all parameters
+        redis_options = {"host": "localhost", "port": 6379}
+        config = create_session_config(
+            user_id="test-user",
+            session_id="test-session",
+            provider="redis",
+            storage_path="/custom/path",
+            temp_dir="/tmp/browser",
+            redis_options=redis_options
+        )
+        
+        self.assertEqual(config["user_id"], "test-user")
+        self.assertEqual(config["session_id"], "test-session")
+        self.assertEqual(config["provider"], "redis")
+        self.assertEqual(config["storage_path"], "/custom/path")
+        self.assertEqual(config["temp_dir"], "/tmp/browser")
+        self.assertEqual(config["redis_options"], redis_options)
+    
+    @patch('browserstate_nova_adapter.BrowserState')
+    def test_config_with_browserstate(self, mock_browserstate):
+        from browserstate_nova_adapter import create_session_config, with_browserstate
+        
+        # Setup mock
+        mock_instance = MagicMock()
+        mock_session = {"path": "/tmp/browser_data"}
+        mock_instance.mount_session.return_value = mock_session
+        mock_browserstate.return_value = mock_instance
+        
+        # Create config
+        config = create_session_config(
+            user_id="test-user",
+            session_id="test-session",
+            provider="local"
+        )
+        
+        # Test using config with context manager
+        with with_browserstate(**config) as user_data_dir:
+            self.assertEqual(user_data_dir, "/tmp/browser_data")
+    
     @patch('browserstate_nova_adapter.BrowserState')
     def test_mount_browserstate(self, mock_browserstate):
         from browserstate_nova_adapter import mount_browserstate, unmount_browserstate


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add Amazon shopping example with session persistence and `create_session_config` function for reusable session configurations.
> 
>   - **New Functionality**:
>     - Adds `create_session_config()` in `__init__.py` to create reusable session configurations for `with_browserstate`.
>     - Demonstrates Amazon shopping automation with session persistence in `README.md`.
>   - **Examples**:
>     - Adds `session_configs.py` to show multiple session configurations for different tasks (Amazon, Gmail, Banking).
>   - **Tests**:
>     - Adds tests for `create_session_config()` in `test_adapter.py`.
>     - Tests `with_browserstate` context manager for session handling and exception safety.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=browserstate-org%2Fbrowserstate-nova-adapter&utm_source=github&utm_medium=referral)<sup> for 47dddd2faa3681d97bc693b77316a0f20c7f6e60. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->